### PR TITLE
Fix reference errors

### DIFF
--- a/lib/node.coffee
+++ b/lib/node.coffee
@@ -22,7 +22,7 @@ class Parent extends EventEmitter
   connect: (@host, @port, @cb) ->
     console.log @node.name, "connecting to", @host, "on", @port
     @ws?.close()
-    @ws = new ws "ws://#{host}:#{port}"
+    @ws = new ws "ws://#{@host}:#{@port}"
     @ws.on 'message', (data) => @recv data, @ws
 
     @ws.on 'open', =>
@@ -122,7 +122,7 @@ class Children extends MsgEmitter
     @listen host, port, cb
 
   listen: (@host, @port, cb) ->
-    console.log @node.name, "listening on", host, "port", port
+    console.log @node.name, "listening on", @host, "port", @port
     @on type: 'ping', scope: 'link', (msg) => @send type: 'pong', scope: 'link', to: msg.from
 
     @wss = new ws.Server {host, port}

--- a/lib/resource.coffee
+++ b/lib/resource.coffee
@@ -255,7 +255,7 @@ class Resource
 
 class Selector
   constructor: (@node, @selector, @updateCB) ->
-    matcher = {type: "resource update", resource: selector}
+    matcher = {type: "resource update", resource: @selector}
 
     #console.log @node.name, "listening for", matcher
     @node.on matcher, @handleMatchUpdate


### PR DESCRIPTION
Related to change in coffeescript 1.9.0 on Jan 29, 2015.

Changed strategy for the generation of internal compiler variable names.
Note that this means that @example function parameters are no longer
available as naked example variables within the function body.
